### PR TITLE
Feature/add config file multihost

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 BRASH is a NASA-funded Phase II STTR focused on developing tools for integrating ROS2 with Flight Software (FSW) tools such as cFS and F'.
 
 ### Contact
-Ana Huaman Quispe ana@traclabs.com
+Questions or comments? Write to brash@traclabs.com
 
 
 # Installation notes for BRASH on Ubuntu 22.04 using ROS2 humble

--- a/run_rosfsw.sh
+++ b/run_rosfsw.sh
@@ -23,8 +23,8 @@ if [[ $DO_LOCAL_SOURCE -eq 1 ]]; then
 fi
 
 # Start ROS FSW Interface
-echo "Starting cfe_bridge"
-ros2 launch cfe_sbn_plugin cfe_sbn_bridge.launch.py &> ${LOG_DIR}/rosfsw_sbn.log &
+echo "Starting cfe_sbn_bridge"
+ros2 launch cfe_sbn_plugin cfe_sbn_bridge.launch.py cfe_sbn_config:='cfe_sbn_config_multihost.yaml' &> ${LOG_DIR}/rosfsw_sbn.log &
 
 # Start ROS FSW CFDP Instance
 echo "Starting ROSGSW CFDP"

--- a/run_rosgsw.sh
+++ b/run_rosgsw.sh
@@ -26,7 +26,7 @@ fi
 #PARAMS="-p \"plugin_params.commandHost=fsw\""
 #export FSW_CMD_HOST=fsw
 echo "Starting cfe_bridge"
-ros2 launch cfe_plugin cfe_bridge.launch.py &> ${LOG_DIR}/rosgsw_cfebridge.log &
+ros2 launch cfe_plugin cfe_bridge.launch.py cfe_config:='cfe_config_multihost.yaml' &> ${LOG_DIR}/rosgsw_cfebridge.log &
 
 # Start ROS GSW CFDP Instance
 echo "Starting ROSGSW CFDP"


### PR DESCRIPTION
This PR should be tested with:

https://github.com/traclabs/cfe_sbn_bridge_plugin/pull/1
https://github.com/traclabs/cfe_ros2_bridge_plugin/pull/1

In short: Both PRs above allow a user to choose a config yaml file for both bridges. This way, a user can write his own config yamls for their specific setup. We used to support this using ENV variables. For ROS2 users, it is a bit easier to use configuration files, as that is the most common way to set up parameters.

This PR updates the scripts for the docker services such that they call the bridges with their corresponding config files (for the multihost setup). Tested this in the docker setup and works as expected.