### PR TITLE
Use Rosbridge server - default package

### DIFF
--- a/https.repos
+++ b/https.repos
@@ -37,5 +37,5 @@ repositories:
     version: devel
   rosbridge_suite:
     type: git
-    url: https://github.com/scottbell/rosbridge_suite.git
+    url: https://github.com/RobotWebTools/rosbridge_suite.git
     version: ros2

--- a/ssh.repos
+++ b/ssh.repos
@@ -37,6 +37,6 @@ repositories:
     version: devel
   rosbridge_suite:
     type: git
-    url: git@github.com:scottbell/rosbridge_suite.git
+    url: git@github.com:RobotWebTools/rosbridge_suite.git
     version: ros2
 


### PR DESCRIPTION
We have been using Scott's version of Rosbridge server, which had some fixes Brash needed. The changes have been merged to the main repo, so this PR changes **rosbridge_server** to use the main repo now.

Reference of the PR: https://github.com/RobotWebTools/rosbridge_suite/pull/883/files